### PR TITLE
Removes auto tax rate selection

### DIFF
--- a/src/features/user/sandbox-testing/InvoiceItemManagement.tsx
+++ b/src/features/user/sandbox-testing/InvoiceItemManagement.tsx
@@ -149,18 +149,6 @@ export function InvoiceItemManagement({
     }
   }, [scenario?.saleTypeId, sellerProvinceId, fetchTaxRatesForScenario]);
 
-  // Auto-select the only available tax rate when available rates change
-  useEffect(() => {
-    if (availableTaxRates.length === 1 && (!selectedTaxRate || selectedTaxRate.rateId !== availableTaxRates[0].rateId)) {
-      const singleRate = availableTaxRates[0];
-      setSelectedTaxRate(singleRate);
-      setFormData((prev) => ({
-        ...prev,
-        tax_rate: singleRate.value,
-      }));
-    }
-  }, [availableTaxRates, selectedTaxRate]);
-
   const filterUomOptionsByHSCode = useCallback(
     async (hsCode: string) => {
       if (!hsCode) {


### PR DESCRIPTION
Removes the automatic selection of the single available tax rate.

This functionality can be better handled elsewhere in the component's logic, or potentially is no longer needed.
