### PR TITLE
Allows manual entry of SRO data

### DIFF
--- a/src/features/user/sandbox-testing/InvoiceItemManagement.tsx
+++ b/src/features/user/sandbox-testing/InvoiceItemManagement.tsx
@@ -1032,9 +1032,13 @@ export function InvoiceItemManagement({
                       </SelectContent>
                     </Select>
                   ) : (
-                    <div className="text-sm text-muted-foreground p-2 border rounded-md bg-muted/30">
-                      No SRO schedules available for this tax rate
-                    </div>
+                    <Input
+                      id="sro-schedule-no"
+                      value={formData.sroScheduleNo || ""}
+                      onChange={(e) => handleFormChange("sroScheduleNo", e.target.value)}
+                      placeholder="Enter SRO Schedule No manually"
+                      className={validationErrors.sroScheduleNo ? "border-red-500" : ""}
+                    />
                   )}
                   {validationErrors.sroScheduleNo && (
                     <p className="text-sm text-red-500">{validationErrors.sroScheduleNo}</p>
@@ -1042,7 +1046,11 @@ export function InvoiceItemManagement({
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="sro-item-serial-no">SRO Item Number</Label>
-                  {!selectedSroSchedule ? (
+                  {!selectedTaxRate ? (
+                    <div className="text-sm text-muted-foreground p-2 border rounded-md bg-muted/30">
+                      Please select a tax rate first
+                    </div>
+                  ) : !selectedSroSchedule && sroScheduleOptions.length > 0 ? (
                     <div className="text-sm text-muted-foreground p-2 border rounded-md bg-muted/30">
                       Please select an SRO schedule first
                     </div>
@@ -1073,9 +1081,13 @@ export function InvoiceItemManagement({
                       </SelectContent>
                     </Select>
                   ) : (
-                    <div className="text-sm text-muted-foreground p-2 border rounded-md bg-muted/30">
-                      No SRO items available for this schedule
-                    </div>
+                    <Input
+                      id="sro-item-serial-no"
+                      value={formData.sroItemSerialNo || ""}
+                      onChange={(e) => handleFormChange("sroItemSerialNo", e.target.value)}
+                      placeholder="Enter SRO Item Number manually"
+                      className={validationErrors.sroItemSerialNo ? "border-red-500" : ""}
+                    />
                   )}
                   {validationErrors.sroItemSerialNo && (
                     <p className="text-sm text-red-500">{validationErrors.sroItemSerialNo}</p>


### PR DESCRIPTION
Allows users to manually enter SRO schedule and item numbers when no options are available.

This change enhances the invoice item management by providing fallback input fields for SRO schedule number and SRO item serial number. This is particularly useful when no SRO schedules or items are available for the selected tax rate, or when the fetched data is incomplete.

The changes include:
- Displaying an input field for manual SRO Schedule No. entry when no schedules are available for the selected tax rate.
- Displaying an input field for manual SRO Item Number entry when no items are available for the selected schedule.
- Adding a message to prompt the user to select a tax rate first.