### PR TITLE
Adds support for fixed and rupee tax rates

### DIFF
--- a/src/shared/services/api/fbrTaxRates.ts
+++ b/src/shared/services/api/fbrTaxRates.ts
@@ -23,21 +23,20 @@ function parseTaxRateDescription(
 ): { unit: "percentage" | "rupee" | "fixed"; formattedValue: string } {
   const desc = description.toLowerCase();
 
-  if (desc.includes("%") || desc.includes("percent")) {
-    return {
-      unit: "percentage",
-      formattedValue: `${value}%`,
-    };
-  } else if (desc.includes("rupee") || desc.includes("rs") || desc.includes("per kg") || desc.includes("per unit")) {
-    return {
-      unit: "rupee",
-      formattedValue: `Rs. ${value}`,
-    };
+  if (desc.includes("exempt") || (value === 0 && desc.includes("0"))) {
+    return { unit: "fixed", formattedValue: "Exempt" };
+  } else if (desc.includes("%") || desc.includes("percent")) {
+    return { unit: "percentage", formattedValue: `${value}%` };
+  } else if (
+    desc.includes("rupee") ||
+    desc.includes("rs") ||
+    desc.includes("per kg") ||
+    desc.includes("per unit") ||
+    desc.includes("kilogram")
+  ) {
+    return { unit: "rupee", formattedValue: `Rs. ${value}` };
   } else {
-    return {
-      unit: "fixed",
-      formattedValue: value.toString(),
-    };
+    return { unit: "fixed", formattedValue: value === 0 ? "Exempt" : `Rs. ${value}` };
   }
 }
 

--- a/src/shared/types/fbr.ts
+++ b/src/shared/types/fbr.ts
@@ -219,7 +219,7 @@ export interface FbrSandboxTestResponse {
  */
 export interface SaleTypeToRateResponse {
   ratE_ID: number; // Unique rate identifier
-  ratE_DESC: string; // Rate description (e.g., "18% along with rupees 60 per kilogram")
+  ratE_DESC: string; // Rate description (e.g., "18% along with rupees 60 per kilogram") can be Rs.100, 5% or Exempt
   ratE_VALUE: number; // Tax rate percentage value
 }
 

--- a/src/shared/types/invoice.ts
+++ b/src/shared/types/invoice.ts
@@ -249,6 +249,7 @@ export interface InvoiceItemForm {
   unit_price: number;
   uom_code: string;
   tax_rate: number;
+  tax_unit?: "percentage" | "rupee" | "fixed";
   invoice_note?: string;
   is_third_schedule: boolean;
   mrp_including_tax?: number;


### PR DESCRIPTION
Extends the invoice item management to support tax rates defined as fixed amounts or rupees, in addition to percentages.
This includes updating the UI to display the tax rate with its unit and modifying the calculation logic to handle different tax unit types.
It also ensures that the tax rate selection correctly filters rates based on both value and unit.
