### PR TITLE
Handles extra tax field conditionally

### DIFF
--- a/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
+++ b/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
@@ -314,6 +314,7 @@ export default function ScenarioInvoiceForm() {
 
       const items: FBRInvoicePayload["items"] = formData.items.map((item) => {
         const SalesTaxCheck = ["SN008", "SN027"].includes(scenario?.id);
+        const ExtraTaxCheck = ["SN028", "SN016"].includes(scenario?.id);
         const valueSalesExcludingST = item.total_amount - item.sales_tax || 0.0;
         const taxRate = taxRates?.find((e) => e.value === item.tax_rate)?.description || `${item.tax_rate}%`;
         return {
@@ -327,7 +328,7 @@ export default function ScenarioInvoiceForm() {
           fixedNotifiedValueOrRetailPrice: SalesTaxCheck ? valueSalesExcludingST : item.fixed_notified_value || 0.0,
           salesTaxApplicable: item.sales_tax,
           salesTaxWithheldAtSource: 0.0,
-          extraTax: 0.0,
+          ...(!ExtraTaxCheck && { extraTax: 0.0 }),
           furtherTax: 0.0,
           sroScheduleNo: item.sroScheduleNo || "",
           fedPayable: 0.0,

--- a/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
+++ b/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
@@ -328,7 +328,7 @@ export default function ScenarioInvoiceForm() {
           fixedNotifiedValueOrRetailPrice: SalesTaxCheck ? valueSalesExcludingST : item.fixed_notified_value || 0.0,
           salesTaxApplicable: item.sales_tax,
           salesTaxWithheldAtSource: 0.0,
-          ...(!ExtraTaxCheck && { extraTax: 0.0 }),
+          extraTax: ExtraTaxCheck ? "" : 0.0,
           furtherTax: 0.0,
           sroScheduleNo: item.sroScheduleNo || "",
           fedPayable: 0.0,

--- a/src/shared/services/api/fbrSubmission.ts
+++ b/src/shared/services/api/fbrSubmission.ts
@@ -1,6 +1,6 @@
 import { HttpClientApi } from "./http-client";
 import { generateFBRInvoiceNumber } from "../supabase/invoice";
-import { FBRInvoiceData, InvoiceItemCalculated } from "@/shared/types/invoice";
+import { FBRInvoiceData, FBRInvoicePayload, InvoiceItemCalculated } from "@/shared/types/invoice";
 import { getScenarioById } from "@/shared/constants";
 
 // FBR API endpoints
@@ -38,7 +38,11 @@ export interface FBRSubmissionResponse {
 /**
  * Convert InvoiceItemCalculated to FBR API format
  */
-function convertItemToFBRFormat(item: InvoiceItemCalculated, saleType: string, scenarioId: string) {
+function convertItemToFBRFormat(
+  item: InvoiceItemCalculated,
+  saleType: string,
+  scenarioId: string
+): FBRInvoicePayload["items"][number] {
   // Format number to appropriate decimal places
   // Quantities can have up to 3 decimal places (e.g., 0.125 kg)
   // Monetary values use 2 decimal places
@@ -61,7 +65,7 @@ function convertItemToFBRFormat(item: InvoiceItemCalculated, saleType: string, s
     fixedNotifiedValueOrRetailPrice: SalesTaxCheck ? valueSalesExcludingST : item.fixed_notified_value || 0.0,
     salesTaxApplicable: parseFloat(formatNumberToString(item.sales_tax)),
     salesTaxWithheldAtSource: 0.0, // Default value - should be calculated based on business rules
-    ...(!ExtraTaxCheck && { extraTax: 0.0 }), // Default value - should be calculated based on business rules
+    extraTax: ExtraTaxCheck ? "" : 0.0,
     furtherTax: 0.0, // Default value - should be calculated based on business rules
     sroScheduleNo: item.sroScheduleNo || (item.is_third_schedule ? "3" : ""), // Use form value or third schedule indicator
     fedPayable: 0.0, // Default value - should be calculated based on business rules

--- a/src/shared/services/api/fbrSubmission.ts
+++ b/src/shared/services/api/fbrSubmission.ts
@@ -38,13 +38,17 @@ export interface FBRSubmissionResponse {
 /**
  * Convert InvoiceItemCalculated to FBR API format
  */
-function convertItemToFBRFormat(item: InvoiceItemCalculated, saleType: string) {
+function convertItemToFBRFormat(item: InvoiceItemCalculated, saleType: string, scenarioId: string) {
   // Format number to appropriate decimal places
   // Quantities can have up to 3 decimal places (e.g., 0.125 kg)
   // Monetary values use 2 decimal places
   const formatNumberToString = (value: number, isQuantity: boolean = false): string => {
     return isQuantity ? value.toFixed(3) : value.toFixed(2);
   };
+
+  const SalesTaxCheck = ["SN008", "SN027"].includes(scenarioId);
+  const ExtraTaxCheck = ["SN028", "SN016"].includes(scenarioId);
+  const valueSalesExcludingST = item.total_amount - item.sales_tax || 0.0;
 
   return {
     hsCode: item.hs_code,
@@ -53,11 +57,11 @@ function convertItemToFBRFormat(item: InvoiceItemCalculated, saleType: string) {
     uoM: item.uom_code,
     quantity: parseFloat(formatNumberToString(item.quantity, true)), // Quantity supports 3 decimal places
     totalValues: parseFloat(formatNumberToString(item.total_amount)),
-    valueSalesExcludingST: parseFloat(formatNumberToString(item.total_amount - item.sales_tax || 0.0)),
-    fixedNotifiedValueOrRetailPrice: parseFloat(formatNumberToString(item.total_amount - item.sales_tax || 0.0)),
+    valueSalesExcludingST: valueSalesExcludingST,
+    fixedNotifiedValueOrRetailPrice: SalesTaxCheck ? valueSalesExcludingST : item.fixed_notified_value || 0.0,
     salesTaxApplicable: parseFloat(formatNumberToString(item.sales_tax)),
     salesTaxWithheldAtSource: 0.0, // Default value - should be calculated based on business rules
-    extraTax: 0.0, // Default value - should be calculated based on business rules
+    ...(!ExtraTaxCheck && { extraTax: 0.0 }), // Default value - should be calculated based on business rules
     furtherTax: 0.0, // Default value - should be calculated based on business rules
     sroScheduleNo: item.sroScheduleNo || (item.is_third_schedule ? "3" : ""), // Use form value or third schedule indicator
     fedPayable: 0.0, // Default value - should be calculated based on business rules
@@ -122,7 +126,7 @@ async function formatInvoiceDataForFBR(invoiceData: FBRInvoiceData, userId: stri
     buyerRegistrationType: invoiceData.buyerRegistrationType || "Registered",
     invoiceRefNo: invoiceRefNo,
     scenarioId: invoiceData.scenarioId,
-    items: invoiceData.items.map((item) => convertItemToFBRFormat(item, saleType)),
+    items: invoiceData.items.map((item) => convertItemToFBRFormat(item, saleType, invoiceData.scenarioId)),
   };
 }
 

--- a/src/shared/types/invoice.ts
+++ b/src/shared/types/invoice.ts
@@ -76,7 +76,7 @@ export interface FBRInvoicePayload {
     fixedNotifiedValueOrRetailPrice: number;
     salesTaxApplicable: number;
     salesTaxWithheldAtSource: number;
-    extraTax: number;
+    extraTax?: number;
     furtherTax: number;
     sroScheduleNo: string;
     fedPayable: number;

--- a/src/shared/types/invoice.ts
+++ b/src/shared/types/invoice.ts
@@ -76,7 +76,7 @@ export interface FBRInvoicePayload {
     fixedNotifiedValueOrRetailPrice: number;
     salesTaxApplicable: number;
     salesTaxWithheldAtSource: number;
-    extraTax?: number;
+    extraTax: number | string;
     furtherTax: number;
     sroScheduleNo: string;
     fedPayable: number;


### PR DESCRIPTION
Updates the extraTax field to be conditionally set based on the scenario, improving data handling.

The `extraTax` field is now conditionally set as an empty string when `ExtraTaxCheck` is true, otherwise it defaults to 0.0. This change ensures that the `extraTax` field is handled correctly in different scenarios.