### PR TITLE
Extends extra tax check to include SN005

### DIFF
--- a/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
+++ b/src/features/user/sandbox-testing/ScenarioInvoiceForm.tsx
@@ -314,7 +314,7 @@ export default function ScenarioInvoiceForm() {
 
       const items: FBRInvoicePayload["items"] = formData.items.map((item) => {
         const SalesTaxCheck = ["SN008", "SN027"].includes(scenario?.id);
-        const ExtraTaxCheck = ["SN028", "SN016"].includes(scenario?.id);
+        const ExtraTaxCheck = ["SN028", "SN016", "SN005"].includes(scenario?.id);
         const valueSalesExcludingST = item.total_amount - item.sales_tax || 0.0;
         const taxRate = taxRates?.find((e) => e.value === item.tax_rate)?.description || `${item.tax_rate}%`;
         return {

--- a/src/shared/services/api/fbrSubmission.ts
+++ b/src/shared/services/api/fbrSubmission.ts
@@ -51,7 +51,7 @@ function convertItemToFBRFormat(
   };
 
   const SalesTaxCheck = ["SN008", "SN027"].includes(scenarioId);
-  const ExtraTaxCheck = ["SN028", "SN016"].includes(scenarioId);
+  const ExtraTaxCheck = ["SN028", "SN016", "SN005"].includes(scenarioId);
   const valueSalesExcludingST = item.total_amount - item.sales_tax || 0.0;
 
   return {


### PR DESCRIPTION
Extends the extra tax check to include scenario ID SN005 in both the invoice form and the FBR submission service. This ensures that the extra tax is correctly applied when the scenario is SN005.